### PR TITLE
Fix default parameter in GramMatrix module

### DIFF
--- a/fast_neural_style/GramMatrix.lua
+++ b/fast_neural_style/GramMatrix.lua
@@ -18,7 +18,12 @@ Output:
 
 function Gram:__init(normalize)
   parent.__init(self)
-  self.normalize = normalize or true
+  if normalize ~= nil then
+    assert(type(normalize) == 'boolean', 'normalize has to be true/false')
+    self.normalize = normalize
+  else
+    self.normalize = true
+  end
   self.buffer = torch.Tensor()
 end
 


### PR DESCRIPTION
Expression `normalize or true` always evaluates to `true`. The correct way is like here https://github.com/torch/nn/blob/master/BatchNormalization.lua#L44