### PR TITLE
Input dir files without extension

### DIFF
--- a/fast_neural_style/utils.lua
+++ b/fast_neural_style/utils.lua
@@ -116,7 +116,7 @@ function M.is_image_file(filename)
     return false
   end
   -- Check against a list of known image extensions
-  local ext = string.lower(paths.extname(filename))
+  local ext = string.lower(paths.extname(filename) or "")
   for _, image_ext in ipairs(IMAGE_EXTS) do
     if ext == image_ext then
       return true


### PR DESCRIPTION
Corrects crash of  fast_neural_style.lua if input dir contains a file without extension (such as a sub-directory) as reported in https://github.com/jcjohnson/fast-neural-style/issues/34 .

BTW, this is my first pull request between forks in github and I am unhappy about the superfluous commit c445481 which resulted from pulling the latest changes from jcjohnson/fast-neural-style. If this is a problem we can ignore this PR and I will come back when I have learned to handle github.