### PR TITLE
correct pixel loss

### DIFF
--- a/train.lua
+++ b/train.lua
@@ -179,7 +179,7 @@ cmd:option('-backend', 'cuda', 'cuda|opencl')
     -- Compute pixel loss and gradient
     local pixel_loss = 0
       if pixel_crit then
-      local pixel_loss = pixel_crit:forward(out, y)
+      pixel_loss = pixel_crit:forward(out, y)
       pixel_loss = pixel_loss * opt.pixel_loss_weight
       local grad_out_pix = pixel_crit:backward(out, y)
       if grad_out then


### PR DESCRIPTION
In the present code, pixel loss is calculated within the loop but afterwards it will be zero always. Removed "local" from a line to add losses to the variable which exists outside of the loop.