### PR TITLE
Fix URLs for downloading models

### DIFF
--- a/models/download_style_transfer_models.sh
+++ b/models/download_style_transfer_models.sh
@@ -1,4 +1,4 @@
-BASE_URL="http://cs.stanford.edu/people/jcjohns/fast-neural-style/models/"
+BASE_URL="https://cs.stanford.edu/people/jcjohns/fast-neural-style/models/"
 
 mkdir -p models/instance_norm
 cd models/instance_norm


### PR DESCRIPTION
Looks like the domain is moving to https only - so the curl commands get a HTML redirect, they now download the right models. 👍 